### PR TITLE
Fix Ubuntu 16.04 bugs with auditd::service and add 18.04 support

### DIFF
--- a/data/Ubuntu-16.04.yaml
+++ b/data/Ubuntu-16.04.yaml
@@ -1,2 +1,3 @@
 ---
 auditd::package_name: auditd
+auditd::rules_file: /etc/audit/audit.rules

--- a/data/Ubuntu-18.04.yaml
+++ b/data/Ubuntu-18.04.yaml
@@ -1,0 +1,1 @@
+Ubuntu-16.04.yaml

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -49,6 +49,7 @@ auditd::rulesd_dir: /etc/audit/rules.d
 auditd::purge_rules: true
 auditd::rules_buffer_size: 8192
 auditd::rules_failure_mode: 1
+auditd::rules_file: /etc/audit/auditd.rules
 
 ## rulesets
 auditd::base_rules: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class auditd (
   Integer $rules_buffer_size,
   Integer[0,2] $rules_failure_mode,
   String $rulesd_dir,
+  String $rules_file,
   Boolean $purge_rules,
   Optional[Array] $base_rules,
   Optional[Array] $main_rules,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -30,7 +30,7 @@ class auditd::service inherits auditd {
   if $auditd::use_augenrules == true {
 
     exec { 'augenrules --load':
-      path        => ['/sbin', '/bin'],
+      path        => ['/sbin', '/bin', '/usr/bin'],
       refreshonly => true,
       subscribe   => [  File["${auditd::rulesd_dir}/10-base.rules"],
                         File["${auditd::rulesd_dir}/30-main.rules"],
@@ -38,7 +38,7 @@ class auditd::service inherits auditd {
                         File["${auditd::rulesd_dir}/99-finalize.rules"] ],
     }
 
-    exec { 'auditctl -R /etc/audit/auditd.rules':
+    exec { "auditctl -R ${auditd::rules_file}":
       path        => ['/sbin', '/bin'],
       refreshonly => true,
       subscribe   => Exec['augenrules --load'],


### PR DESCRIPTION
augenrules is a bash script that needs /usr/bin/awk and wasn't working without that in the path.

The filename it generates is /etc/audit/audit.rules so have created a var for that.

18.04 is the same as 16.04.