### PR TITLE
Puppet 6 Support

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,5 +1,5 @@
 ---
-version: 4
+version: 5
 datadir: data
 hierarchy:
   - name: "Major Version"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "nexcess-auditd",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "author": "Nexcess",
   "summary": "Installs, configures, and manages auditd.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.5.0 < 6.0.0"
+      "version_requirement": ">= 4.5.0 < 8.0.0"
     }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 8.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -27,12 +27,6 @@
         "6",
         "7"
       ]
-    },
-    {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
These changes bump metadata and dependency requirements to allow for Puppet 6 / 7 support.

Additionally starting with release 4.0.0, we will no longer be officially supporting Ubuntu, and will only be supporting RHEL/CentOS 6 and 7.